### PR TITLE
Minor improvements to the codebase

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,18 @@
+; https://editorconfig.org/
+
+root = true
+
+[*]
+insert_final_newline = true
+charset = utf-8
+trim_trailing_whitespace = true
+indent_style = space
+indent_size = 2
+
+[{go.mod,go.sum,*.go}]
+indent_style = tab
+indent_size = 4
+
+[*.md]
+indent_size = 4
+trim_trailing_whitespace = false

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,8 +4,8 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.14.x, 1.15.x]
-        platform: [ubuntu-16.04, ubuntu-latest]
+        go-version: [1.x]
+        platform: [ubuntu-latest]
     runs-on: ${{ matrix.platform }}
     steps:
       - name: Install Go
@@ -13,26 +13,25 @@ jobs:
         with:
           go-version: ${{ matrix.go-version }}
       - name: Install staticcheck
-        run: pwd && cd .. && go get -v -u honnef.co/go/tools/cmd/staticcheck && cd -
+        run: go install honnef.co/go/tools/cmd/staticcheck@latest
         shell: bash
       - name: Install golint
-        run: pwd && cd .. && go get -v -u golang.org/x/lint/golint && cd -
+        run: go install golang.org/x/lint/golint@latest
         shell: bash
       - name: Update PATH
-        # https://github.com/actions/setup-go/issues/12#issuecomment-524631719
-        run: echo "##[add-path]$(go env GOPATH)/bin"
+        run: echo "$(go env GOPATH)/bin" >> $GITHUB_PATH
         shell: bash
       - name: Checkout code
         uses: actions/checkout@v1
       - name: Fmt
         if: matrix.platform != 'windows-latest' # :(
-        run: "F=$(gofmt -l .) ; if [[ $F ]] ; then echo $F ; exit 1 ; fi"
+        run: "diff <(gofmt -d .) <(printf '')"
         shell: bash
       - name: Vet
         run: go vet ./...
-      - name: Staticcheck
+      - name: Static check
         run: staticcheck ./...
-      - name: Lint
+      - name: Go lint
         run: golint ./...
       - name: Test
         run: go test -race ./...

--- a/README.md
+++ b/README.md
@@ -4,17 +4,18 @@ geroz-e wraps `exec.Cmd` and allows user to propagate signals to the underlying 
 
 ## Usage
 
-Following example is the simplest signal propagator.
+The following example is the simplest signal propagator.
 
 ```go
 import (
-    "github.com/kyslik/geroz"
     "log"
     "os"
+
+    "github.com/kyslik/geroz"
 )
 
 func main() {
-    // initialize command `*exec.Cmd` with sane defaults
+    // initialize command `*exec.Cmd`
     c, e := geroz.NewCommand()
     if e != nil {
         log.Fatalf("failed to initialize command: %v\n", e)
@@ -29,7 +30,7 @@ func main() {
     ctx, cancel := context.WithCancel(context.Background())
     defer cancel()
 
-    // set up propagating signals to the process c
+    // set up propagating signals to the process `c`
     go geroz.PropagateSignals(ctx, c)
 
     // wait for the process to exit (blocking)
@@ -44,5 +45,5 @@ For more examples see directory [examples](./examples).
 
 ## TODO
 
-- [ ] make test pass when using `go test -race`
+- [ ] make a test pass when using `go test -race`
 - [ ] implement catching zombie processes - <https://github.com/ramr/go-reaper>

--- a/examples/enver/main.go
+++ b/examples/enver/main.go
@@ -1,13 +1,14 @@
 package main
 
 import (
-	"github.com/kyslik/geroz"
 	"log"
 	"os"
+
+	"github.com/kyslik/geroz"
 )
 
 func main() {
-	// Simulate passing in "env" binary as first argument
+	// simulate passing in "env" binary as the first argument
 	if len(os.Args) == 1 {
 		os.Args = append(os.Args, "env")
 	}

--- a/examples/trapper/trapper.sh
+++ b/examples/trapper/trapper.sh
@@ -12,4 +12,4 @@ func_trap() {
 }
 
 trap_with_arg func_trap INT QUIT URG WINCH USR1 USR2
-read
+read -r

--- a/geroz.go
+++ b/geroz.go
@@ -64,7 +64,7 @@ func PropagateSignals(ctx context.Context, cmd *exec.Cmd) {
 	}
 }
 
-// WaitCommand is a blocking function that waits for `cmd` to exit and returns it's exit code.
+// WaitCommand is a blocking function that waits for `cmd` to exit and returns its exit code.
 func WaitCommand(cmd *exec.Cmd) (int, error) {
 	err := cmd.Wait()
 	if err != nil {

--- a/geroz_unix_test.go
+++ b/geroz_unix_test.go
@@ -6,7 +6,6 @@ import (
 	"crypto/sha1"
 	"encoding/hex"
 	"fmt"
-	"github.com/kyslik/geroz"
 	"io"
 	"io/ioutil"
 	"os"
@@ -18,6 +17,8 @@ import (
 	"syscall"
 	"testing"
 	"time"
+
+	"github.com/kyslik/geroz"
 )
 
 // disable output of command `c`


### PR DESCRIPTION
This PR adds `.editorconfig`, amends import order in examples and README as well as adds newer versions of Go to the testing matrix.

The GitHub workflows are mainly copied from https://github.com/peterbourgon/ff/blob/main/.github/workflows/test.yml ❤️ .